### PR TITLE
Update script.js

### DIFF
--- a/Easy/StopWatch/script.js
+++ b/Easy/StopWatch/script.js
@@ -69,5 +69,6 @@ stopButton.addEventListener('click', stopStopwatch);
 resetButton.addEventListener('click', resetStopwatch);
 lapButton.addEventListener('click', recordLap); // Add event listener for lap button
 
+// Initial button states
 stopButton.disabled = true;
 lapButton.disabled = true; // Disable lap button initially


### PR DESCRIPTION
I did changes that i wrote in issue number #14 
have a look into it 

Lap Button: Disabled in both stopStopwatch and resetStopwatch functions to ensure it is only active while the stopwatch is running.

Initial Button States: Confirmed that Lap and Stop buttons are disabled initially when the page loads.